### PR TITLE
fix: 질문 필터 버튼 위치 조정, PostPage 전체 width 조정

### DIFF
--- a/src/pages/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage.jsx
@@ -151,7 +151,7 @@ function PostPage() {
   }, []);
 
   return (
-    <div className="flex flex-col bg-[#F9F9F9]">
+    <div className="w-[100vw] flex flex-col bg-[#F9F9F9]">
       <div className="relative flex flex-col items-center justify-center">
         <div className="mt-[50px] z-10 gap-[20px] flex flex-col items-center justify-center">
           <Link to="/">

--- a/src/pages/PostPage/components/QuestionList.jsx
+++ b/src/pages/PostPage/components/QuestionList.jsx
@@ -12,7 +12,7 @@ function QuestionList({ questionData }) {
   return (
     <>
       {questionData.length !== 0 && (
-        <div className="flex justify-end gap-[20px] mr-[20px] mb-[20px] ">
+        <div className="w-[275px] md:w-[652px] flex justify-end gap-[20px] mr-[20px] mb-[20px]">
           <button
             onClick={() => setDisplayMode('all')}
             className={`text-[15px] font-[400] ${displayMode === 'all' ? 'text-[#1877f2]' : 'text-[#542F1A]'}`}


### PR DESCRIPTION
## 질문 필터 버튼 위치 조정
조건에 해당하는 질문이 없을 때에도 똑같이 우측에 위치하도록 수정하였습니다

<img width="1287" alt="image" src="https://github.com/PTO-Zero/Openmind/assets/112617546/4cd3d70c-d448-48eb-9835-260d4776b0e6">
<img width="751" alt="image" src="https://github.com/PTO-Zero/Openmind/assets/112617546/b04d18e3-632d-45fa-937b-76e09b346925">

## 전체 width 수정
질문이 있을 때, 없을 때 페이지 안의 전체 요소가 정말 약~~~~간 오른쪽으로 밀리는 현상이 발생해서
width 수정하였습니다

- 기존

https://github.com/PTO-Zero/Openmind/assets/112617546/824c5aca-4a15-49fd-ab34-d1a1126dc279

